### PR TITLE
fix: better name for msgAudit apis

### DIFF
--- a/apis.md.go
+++ b/apis.md.go
@@ -324,57 +324,57 @@ func (c *WorkwxApp) execMediaUploadImg(req reqMediaUploadImg) (respMediaUploadIm
 	return resp, nil
 }
 
-// execListPermitUser 获取会话内容存档开启成员列表
-func (c *WorkwxApp) execListPermitUser(req reqListPermitUser) (respListPermitUser, error) {
-	var resp respListPermitUser
+// execMsgAuditListPermitUser 获取会话内容存档开启成员列表
+func (c *WorkwxApp) execMsgAuditListPermitUser(req reqMsgAuditListPermitUser) (respMsgAuditListPermitUser, error) {
+	var resp respMsgAuditListPermitUser
 	err := c.executeQyapiJSONPost("/cgi-bin/msgaudit/get_permit_user_list", req, &resp, true)
 	if err != nil {
-		return respListPermitUser{}, err
+		return respMsgAuditListPermitUser{}, err
 	}
 	if bizErr := resp.TryIntoErr(); bizErr != nil {
-		return respListPermitUser{}, bizErr
+		return respMsgAuditListPermitUser{}, bizErr
 	}
 
 	return resp, nil
 }
 
-// execCheckSingleAgree 获取会话同意情况（单聊）
-func (c *WorkwxApp) execCheckSingleAgree(req reqCheckSingleAgree) (respCheckSingleAgree, error) {
-	var resp respCheckSingleAgree
+// execMsgAuditCheckSingleAgree 获取会话同意情况（单聊）
+func (c *WorkwxApp) execMsgAuditCheckSingleAgree(req reqMsgAuditCheckSingleAgree) (respMsgAuditCheckSingleAgree, error) {
+	var resp respMsgAuditCheckSingleAgree
 	err := c.executeQyapiJSONPost("/cgi-bin/msgaudit/check_single_agree", req, &resp, true)
 	if err != nil {
-		return respCheckSingleAgree{}, err
+		return respMsgAuditCheckSingleAgree{}, err
 	}
 	if bizErr := resp.TryIntoErr(); bizErr != nil {
-		return respCheckSingleAgree{}, bizErr
+		return respMsgAuditCheckSingleAgree{}, bizErr
 	}
 
 	return resp, nil
 }
 
-// execCheckRoomAgree 获取会话同意情况（群聊）
-func (c *WorkwxApp) execCheckRoomAgree(req reqCheckRoomAgree) (respCheckRoomAgree, error) {
-	var resp respCheckRoomAgree
+// execMsgAuditCheckRoomAgree 获取会话同意情况（群聊）
+func (c *WorkwxApp) execMsgAuditCheckRoomAgree(req reqMsgAuditCheckRoomAgree) (respMsgAuditCheckRoomAgree, error) {
+	var resp respMsgAuditCheckRoomAgree
 	err := c.executeQyapiJSONPost("/cgi-bin/msgaudit/check_room_agree", req, &resp, true)
 	if err != nil {
-		return respCheckRoomAgree{}, err
+		return respMsgAuditCheckRoomAgree{}, err
 	}
 	if bizErr := resp.TryIntoErr(); bizErr != nil {
-		return respCheckRoomAgree{}, bizErr
+		return respMsgAuditCheckRoomAgree{}, bizErr
 	}
 
 	return resp, nil
 }
 
-// execGetGroupChat 获取会话内容存档内部群信息
-func (c *WorkwxApp) execGetGroupChat(req reqGetGroupChat) (respGetGroupChat, error) {
-	var resp respGetGroupChat
+// execMsgAuditGetGroupChat 获取会话内容存档内部群信息
+func (c *WorkwxApp) execMsgAuditGetGroupChat(req reqMsgAuditGetGroupChat) (respMsgAuditGetGroupChat, error) {
+	var resp respMsgAuditGetGroupChat
 	err := c.executeQyapiJSONPost("/cgi-bin/msgaudit/groupchat/get", req, &resp, true)
 	if err != nil {
-		return respGetGroupChat{}, err
+		return respMsgAuditGetGroupChat{}, err
 	}
 	if bizErr := resp.TryIntoErr(); bizErr != nil {
-		return respGetGroupChat{}, bizErr
+		return respMsgAuditGetGroupChat{}, bizErr
 	}
 
 	return resp, nil

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -161,7 +161,7 @@ Name|Request Type|Response Type|Access Token|URL|Doc
 
 Name|Request Type|Response Type|Access Token|URL|Doc
 :---|------------|-------------|------------|:--|:--
-`execListPermitUser`|`reqListPermitUser`|`respListPermitUser`|+|`POST /cgi-bin/msgaudit/get_permit_user_list`|[获取会话内容存档开启成员列表](https://work.weixin.qq.com/api/doc/90000/90135/91614)
-`execCheckSingleAgree`|`reqCheckSingleAgree`|`respCheckSingleAgree`|+|`POST /cgi-bin/msgaudit/check_single_agree`|[获取会话同意情况（单聊）](https://work.weixin.qq.com/api/doc/90000/90135/91782)
-`execCheckRoomAgree`|`reqCheckRoomAgree`|`respCheckRoomAgree`|+|`POST /cgi-bin/msgaudit/check_room_agree`|[获取会话同意情况（群聊）](https://work.weixin.qq.com/api/doc/90000/90135/91782)
-`execGetGroupChat`|`reqGetGroupChat`|`respGetGroupChat`|+|`POST /cgi-bin/msgaudit/groupchat/get`|[获取会话内容存档内部群信息](https://work.weixin.qq.com/api/doc/90000/90135/92951)
+`execMsgAuditListPermitUser`|`reqMsgAuditListPermitUser`|`respMsgAuditListPermitUser`|+|`POST /cgi-bin/msgaudit/get_permit_user_list`|[获取会话内容存档开启成员列表](https://work.weixin.qq.com/api/doc/90000/90135/91614)
+`execMsgAuditCheckSingleAgree`|`reqMsgAuditCheckSingleAgree`|`respMsgAuditCheckSingleAgree`|+|`POST /cgi-bin/msgaudit/check_single_agree`|[获取会话同意情况（单聊）](https://work.weixin.qq.com/api/doc/90000/90135/91782)
+`execMsgAuditCheckRoomAgree`|`reqMsgAuditCheckRoomAgree`|`respMsgAuditCheckRoomAgree`|+|`POST /cgi-bin/msgaudit/check_room_agree`|[获取会话同意情况（群聊）](https://work.weixin.qq.com/api/doc/90000/90135/91782)
+`execMsgAuditGetGroupChat`|`reqMsgAuditGetGroupChat`|`respMsgAuditGetGroupChat`|+|`POST /cgi-bin/msgaudit/groupchat/get`|[获取会话内容存档内部群信息](https://work.weixin.qq.com/api/doc/90000/90135/92951)

--- a/models.go
+++ b/models.go
@@ -588,13 +588,13 @@ type JSCodeSession struct {
 	SessionKey string `json:"session_key"`
 }
 
-type reqListPermitUser struct {
+type reqMsgAuditListPermitUser struct {
 	MsgAuditEdition MsgAuditEdition `json:"type"`
 }
 
-var _ bodyer = reqListPermitUser{}
+var _ bodyer = reqMsgAuditListPermitUser{}
 
-func (x reqListPermitUser) intoBody() ([]byte, error) {
+func (x reqMsgAuditListPermitUser) intoBody() ([]byte, error) {
 	result, err := json.Marshal(x)
 	if err != nil {
 		return nil, err
@@ -603,18 +603,18 @@ func (x reqListPermitUser) intoBody() ([]byte, error) {
 	return result, nil
 }
 
-type respListPermitUser struct {
+type respMsgAuditListPermitUser struct {
 	respCommon
 	IDs []string `json:"ids"`
 }
 
-type reqCheckSingleAgree struct {
-	Infos []CheckSingleAgreeUserInfo `json:"info"`
+type reqMsgAuditCheckSingleAgree struct {
+	Infos []CheckMsgAuditSingleAgreeUserInfo `json:"info"`
 }
 
-var _ bodyer = reqCheckSingleAgree{}
+var _ bodyer = reqMsgAuditCheckSingleAgree{}
 
-func (x reqCheckSingleAgree) intoBody() ([]byte, error) {
+func (x reqMsgAuditCheckSingleAgree) intoBody() ([]byte, error) {
 	result, err := json.Marshal(x)
 	if err != nil {
 		return nil, err
@@ -623,7 +623,7 @@ func (x reqCheckSingleAgree) intoBody() ([]byte, error) {
 	return result, nil
 }
 
-type respCheckSingleAgree struct {
+type respMsgAuditCheckSingleAgree struct {
 	respCommon
 	AgreeInfo []struct {
 		UserID           string              `json:"userid"`
@@ -633,10 +633,10 @@ type respCheckSingleAgree struct {
 	} `json:"agreeinfo"`
 }
 
-func (x respCheckSingleAgree) intoCheckSingleAgreeInfoList() (resp []CheckSingleAgreeInfo) {
+func (x respMsgAuditCheckSingleAgree) intoCheckSingleAgreeInfoList() (resp []CheckMsgAuditSingleAgreeInfo) {
 	for _, agreeInfo := range x.AgreeInfo {
-		resp = append(resp, CheckSingleAgreeInfo{
-			CheckSingleAgreeUserInfo: CheckSingleAgreeUserInfo{
+		resp = append(resp, CheckMsgAuditSingleAgreeInfo{
+			CheckMsgAuditSingleAgreeUserInfo: CheckMsgAuditSingleAgreeUserInfo{
 				UserID:         agreeInfo.UserID,
 				ExternalOpenID: agreeInfo.ExternalOpenID,
 			},
@@ -647,13 +647,13 @@ func (x respCheckSingleAgree) intoCheckSingleAgreeInfoList() (resp []CheckSingle
 	return resp
 }
 
-type reqCheckRoomAgree struct {
+type reqMsgAuditCheckRoomAgree struct {
 	RoomID string `json:"roomid"`
 }
 
-var _ bodyer = reqCheckRoomAgree{}
+var _ bodyer = reqMsgAuditCheckRoomAgree{}
 
-func (x reqCheckRoomAgree) intoBody() ([]byte, error) {
+func (x reqMsgAuditCheckRoomAgree) intoBody() ([]byte, error) {
 	result, err := json.Marshal(x)
 	if err != nil {
 		return nil, err
@@ -662,7 +662,7 @@ func (x reqCheckRoomAgree) intoBody() ([]byte, error) {
 	return result, nil
 }
 
-type respCheckRoomAgree struct {
+type respMsgAuditCheckRoomAgree struct {
 	respCommon
 	AgreeInfo []struct {
 		StatusChangeTime int                 `json:"status_change_time"`
@@ -671,9 +671,9 @@ type respCheckRoomAgree struct {
 	} `json:"agreeinfo"`
 }
 
-func (x respCheckRoomAgree) intoCheckRoomAgreeInfoList() (resp []CheckRoomAgreeInfo) {
+func (x respMsgAuditCheckRoomAgree) intoCheckRoomAgreeInfoList() (resp []CheckMsgAuditRoomAgreeInfo) {
 	for _, agreeInfo := range x.AgreeInfo {
-		resp = append(resp, CheckRoomAgreeInfo{
+		resp = append(resp, CheckMsgAuditRoomAgreeInfo{
 			StatusChangeTime: time.Unix(int64(agreeInfo.StatusChangeTime), 0),
 			AgreeStatus:      agreeInfo.AgreeStatus,
 			ExternalOpenID:   agreeInfo.ExternalOpenID,
@@ -682,13 +682,13 @@ func (x respCheckRoomAgree) intoCheckRoomAgreeInfoList() (resp []CheckRoomAgreeI
 	return resp
 }
 
-type reqGetGroupChat struct {
+type reqMsgAuditGetGroupChat struct {
 	RoomID string `json:"roomid"`
 }
 
-var _ bodyer = reqGetGroupChat{}
+var _ bodyer = reqMsgAuditGetGroupChat{}
 
-func (x reqGetGroupChat) intoBody() ([]byte, error) {
+func (x reqMsgAuditGetGroupChat) intoBody() ([]byte, error) {
 	result, err := json.Marshal(x)
 	if err != nil {
 		return nil, err
@@ -697,7 +697,7 @@ func (x reqGetGroupChat) intoBody() ([]byte, error) {
 	return result, nil
 }
 
-type respGetGroupChat struct {
+type respMsgAuditGetGroupChat struct {
 	respCommon
 	Members []struct {
 		MemberID int `json:"memberid"`
@@ -709,13 +709,13 @@ type respGetGroupChat struct {
 	Notice         string `json:"notice"`
 }
 
-func (x respGetGroupChat) intoGroupChat() (resp GroupChat) {
+func (x respMsgAuditGetGroupChat) intoGroupChat() (resp MsgAuditGroupChat) {
 	resp.Creator = x.Creator
 	resp.Notice = x.Notice
 	resp.RoomName = x.RoomName
 	resp.RoomCreateTime = time.Unix(int64(x.RoomCreateTime), 0)
 	for _, member := range x.Members {
-		resp.Members = append(resp.Members, GroupChatMember{
+		resp.Members = append(resp.Members, MsgAuditGroupChatMember{
 			MemberID: member.MemberID,
 			JoinTime: time.Unix(int64(member.JoinTime), 0),
 		})

--- a/msg_audit.go
+++ b/msg_audit.go
@@ -16,26 +16,26 @@ const (
 	MsgAuditAgreeStatusDefaultAgree = "Default_Agree"
 )
 
-// CheckSingleAgreeUserInfo 获取会话同意情况（单聊）内外成员
-type CheckSingleAgreeUserInfo struct {
+// CheckMsgAuditSingleAgreeUserInfo 获取会话同意情况（单聊）内外成员
+type CheckMsgAuditSingleAgreeUserInfo struct {
 	// UserID 内部成员的userid
 	UserID string `json:"userid"`
 	// ExternalOpenID 外部成员的externalopenid
 	ExternalOpenID string `json:"exteranalopenid"`
 }
 
-// CheckSingleAgreeInfo 获取会话同意情况（单聊）同意信息
-type CheckSingleAgreeInfo struct {
-	CheckSingleAgreeUserInfo
+// CheckMsgAuditSingleAgreeInfo 获取会话同意情况（单聊）同意信息
+type CheckMsgAuditSingleAgreeInfo struct {
+	CheckMsgAuditSingleAgreeUserInfo
 	// AgreeStatus 同意:”Agree”，不同意:”Disagree”，默认同意:”Default_Agree”
 	AgreeStatus MsgAuditAgreeStatus
 	// StatusChangeTime 同意状态改变的具体时间
 	StatusChangeTime time.Time
 }
 
-// CheckSingleAgree 获取会话同意情况（单聊）
-func (c *WorkwxApp) CheckSingleAgree(infos []CheckSingleAgreeUserInfo) ([]CheckSingleAgreeInfo, error) {
-	resp, err := c.execCheckSingleAgree(reqCheckSingleAgree{
+// CheckMsgAuditSingleAgree 获取会话同意情况（单聊）
+func (c *WorkwxApp) CheckMsgAuditSingleAgree(infos []CheckMsgAuditSingleAgreeUserInfo) ([]CheckMsgAuditSingleAgreeInfo, error) {
+	resp, err := c.execMsgAuditCheckSingleAgree(reqMsgAuditCheckSingleAgree{
 		Infos: infos,
 	})
 	if err != nil {
@@ -44,8 +44,8 @@ func (c *WorkwxApp) CheckSingleAgree(infos []CheckSingleAgreeUserInfo) ([]CheckS
 	return resp.intoCheckSingleAgreeInfoList(), nil
 }
 
-// CheckRoomAgreeInfo 获取会话同意情况（群聊）同意信息
-type CheckRoomAgreeInfo struct {
+// CheckMsgAuditRoomAgreeInfo 获取会话同意情况（群聊）同意信息
+type CheckMsgAuditRoomAgreeInfo struct {
 	// StatusChangeTime 同意状态改变的具体时间
 	StatusChangeTime time.Time
 	// AgreeStatus 同意:”Agree”，不同意:”Disagree”，默认同意:”Default_Agree”
@@ -54,9 +54,9 @@ type CheckRoomAgreeInfo struct {
 	ExternalOpenID string
 }
 
-// CheckRoomAgree 获取会话同意情况（群聊）
-func (c *WorkwxApp) CheckRoomAgree(roomId string) ([]CheckRoomAgreeInfo, error) {
-	resp, err := c.execCheckRoomAgree(reqCheckRoomAgree{
+// CheckMsgAuditRoomAgree 获取会话同意情况（群聊）
+func (c *WorkwxApp) CheckMsgAuditRoomAgree(roomId string) ([]CheckMsgAuditRoomAgreeInfo, error) {
+	resp, err := c.execMsgAuditCheckRoomAgree(reqMsgAuditCheckRoomAgree{
 		RoomID: roomId,
 	})
 	if err != nil {
@@ -77,9 +77,9 @@ const (
 	MsgAuditEditionEnterprise MsgAuditEdition = 3
 )
 
-// ListPermitUser 获取会话内容存档开启成员列表
-func (c *WorkwxApp) ListPermitUser(msgAuditEdition MsgAuditEdition) ([]string, error) {
-	resp, err := c.execListPermitUser(reqListPermitUser{
+// ListMsgAuditPermitUser 获取会话内容存档开启成员列表
+func (c *WorkwxApp) ListMsgAuditPermitUser(msgAuditEdition MsgAuditEdition) ([]string, error) {
+	resp, err := c.execMsgAuditListPermitUser(reqMsgAuditListPermitUser{
 		MsgAuditEdition: msgAuditEdition,
 	})
 	if err != nil {
@@ -88,18 +88,18 @@ func (c *WorkwxApp) ListPermitUser(msgAuditEdition MsgAuditEdition) ([]string, e
 	return resp.IDs, nil
 }
 
-// GroupChatMember 获取会话内容存档内部群成员
-type GroupChatMember struct {
+// MsgAuditGroupChatMember 获取会话内容存档内部群成员
+type MsgAuditGroupChatMember struct {
 	// MemberID roomid群成员的id，userid
 	MemberID int
 	// JoinTime roomid群成员的入群时间
 	JoinTime time.Time
 }
 
-// GroupChat 获取会话内容存档内部群信息
-type GroupChat struct {
+// MsgAuditGroupChat 获取会话内容存档内部群信息
+type MsgAuditGroupChat struct {
 	// Members roomid对应的群成员列表
-	Members []GroupChatMember
+	Members []MsgAuditGroupChatMember
 	// RoomName roomid对应的群名称
 	RoomName string
 	// Creator roomid对应的群创建者，userid
@@ -110,9 +110,9 @@ type GroupChat struct {
 	Notice string
 }
 
-// GetGroupChat 获取会话内容存档内部群信息
-func (c *WorkwxApp) GetGroupChat(roomID string) (*GroupChat, error) {
-	resp, err := c.execGetGroupChat(reqGetGroupChat{
+// GetMsgAuditGroupChat 获取会话内容存档内部群信息
+func (c *WorkwxApp) GetMsgAuditGroupChat(roomID string) (*MsgAuditGroupChat, error) {
+	resp, err := c.execMsgAuditGetGroupChat(reqMsgAuditGetGroupChat{
 		RoomID: roomID,
 	})
 	if err != nil {


### PR DESCRIPTION
add prefix `MsgAudit` in all msgAudit apis

it's my fault, forget make same style like `{action}{api_scope}{source}`, so `ListMsgAuditPermitUser` is better than `ListPermitUser`, then i add the api scope `MsgAudit` to fix that