### PR TITLE
fix the type of group chat member ID in message audit feature: int -> string

### DIFF
--- a/models.go
+++ b/models.go
@@ -740,8 +740,8 @@ func (x reqMsgAuditGetGroupChat) intoBody() ([]byte, error) {
 type respMsgAuditGetGroupChat struct {
 	respCommon
 	Members []struct {
-		MemberID int `json:"memberid"`
-		JoinTime int `json:"jointime"`
+		MemberID string `json:"memberid"`
+		JoinTime int    `json:"jointime"`
 	} `json:"members"`
 	RoomName       string `json:"roomname"`
 	Creator        string `json:"creator"`

--- a/msg_audit.go
+++ b/msg_audit.go
@@ -91,7 +91,7 @@ func (c *WorkwxApp) ListMsgAuditPermitUser(msgAuditEdition MsgAuditEdition) ([]s
 // MsgAuditGroupChatMember 获取会话内容存档内部群成员
 type MsgAuditGroupChatMember struct {
 	// MemberID roomid群成员的id，userid
-	MemberID int
+	MemberID string
 	// JoinTime roomid群成员的入群时间
 	JoinTime time.Time
 }


### PR DESCRIPTION
A demo response from the `msgaudit/groupchat/get` API(https://qyapi.weixin.qq.com/cgi-bin/msgaudit/groupchat/get?access_token=ACCESS_TOKEN):
```JSON
{
    "roomname": "蓦然回首",
    "creator": "ZhangWenChao",
    "room_create_time": 1592361604,
    "notice": "",
    "members": [
        {
            "memberid": "ZhangWenChao",
            "jointime": 1592361605
        },
        {
            "memberid": "xujinsheng",
            "jointime": 1592377076
        }
    ],
    "errcode": 0,
    "errmsg": "ok"
}
```
The member id's type should be `string` instead of `int`.