### PR TITLE
fix(recipient): replace isIndividualTargetsEmpty method call with dir…

### DIFF
--- a/recipient.go
+++ b/recipient.go
@@ -81,7 +81,7 @@ func (x *Recipient) isValidForKfSend() bool {
 		return false
 	}
 
-	if !x.isIndividualTargetsEmpty() {
+	if len(x.UserIDs) == 0 {
 		return false
 	}
 


### PR DESCRIPTION

> isValidForKfSend函数有问题，除了OpenKfID外，UserIDs也应该有值
> 
> 但是UserIDs与OpenKfID同时有值时，isValidForKfSend校验不通过
> 
> 参考：https://developer.work.weixin.qq.com/document/path/94677
> 
> touser、open_kfid两个为必填字段

修复客服消息无法发送的问题

Fixes #206 