### PR TITLE
feat(media)：实现获取临时素材API支持

### DIFF
--- a/apis.md.go
+++ b/apis.md.go
@@ -2,6 +2,8 @@
 
 package workwx
 
+import "io"
+
 // execGetAccessToken 获取access_token
 func (c *WorkwxApp) execGetAccessToken(req reqAccessToken) (respAccessToken, error) {
 	var resp respAccessToken
@@ -451,6 +453,11 @@ func (c *WorkwxApp) execMediaUploadImg(req reqMediaUploadImg) (respMediaUploadIm
 	}
 
 	return resp, nil
+}
+
+// execMediaGet 获取临时素材
+func (c *WorkwxApp) execMediaGet(req reqMediaGet) (io.ReadCloser, error) {
+	return executeQyapiGetBinary(c, "/cgi-bin/media/get", req, true)
 }
 
 // execOAGetTemplateDetail 获取审批模板详情

--- a/client.go
+++ b/client.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"mime/multipart"
 	"net/url"
+	"strings"
 )
 
 // Workwx 企业微信客户端
@@ -133,6 +135,63 @@ func executeQyapiGet[T urlValuer, U tryIntoErr](
 	}
 
 	return nil
+}
+
+// executeQyapiGetBinary 执行 GET 请求，返回二进制响应体（用于下载文件等）
+// 如果响应是 JSON 错误，则返回错误
+// executeQyapiGetStream 执行 GET 请求，返回数据流。
+// 注意：调用者必须负责关闭返回的 io.ReadCloser
+func executeQyapiGetBinary[T urlValuer](
+	c *WorkwxApp,
+	path string,
+	req T,
+	withAccessToken bool,
+) (io.ReadCloser, error) {
+	urlObj, err := c.composeQyapiURLWithToken(path, req, withAccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.opts.HTTP.Get(urlObj.String())
+	if err != nil {
+		return nil, makeRequestErr(err)
+	}
+
+	// 重点逻辑：先检查这是否是一个 JSON 报错
+	// 企微 API 坑点：下载文件失败时，会返回 application/json 和错误码
+	contentType := resp.Header.Get("Content-Type")
+	if strings.Contains(contentType, "application/json") {
+		// 既然是 JSON，说明不是我们要的文件流，必须读出来检查错误
+		defer resp.Body.Close() // 读完错误信息要关闭
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, makeRespUnmarshalErr(err)
+		}
+
+		var errResp respCommon
+		if err := json.Unmarshal(body, &errResp); err == nil {
+			if errResp.ErrCode != 0 {
+				return nil, &WorkwxClientError{
+					Code: errResp.ErrCode,
+					Msg:  errResp.ErrMsg,
+				}
+			}
+		}
+		// 极少情况：Content-Type 是 json 但内容没报错，或者无法解析，
+		// 这种情况视作业务逻辑不明，返回错误比较安全
+		return nil, fmt.Errorf("unexpected json response for download api")
+	}
+
+	// 检查 HTTP 状态码 (非 200 也是错误)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		return nil, fmt.Errorf("http request failed: %s", resp.Status)
+	}
+
+	// 成功！返回 resp.Body 这个“水管”给上层去读
+	// 千万不要在这里 defer resp.Body.Close()，否则上层拿到的是关掉的流
+	return resp.Body, nil
 }
 
 func executeQyapiJSONPost[T bodyer, U tryIntoErr](

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -158,7 +158,7 @@ Name|Request Type|Response Type|Access Token|URL|Doc
 :---|------------|-------------|------------|:--|:--
 `execMediaUpload`|`reqMediaUpload`|`respMediaUpload`|+|`POST(media) /cgi-bin/media/upload`|[上传临时素材](https://work.weixin.qq.com/api/doc#90000/90135/90253)
 `execMediaUploadImg`|`reqMediaUploadImg`|`respMediaUploadImg`|+|`POST(media) /cgi-bin/media/uploadimg`|[上传永久图片](https://work.weixin.qq.com/api/doc#90000/90135/90256)
-`execMediaGet`|TODO|TODO|+|`GET /cgi-bin/media/get`|[获取临时素材](https://work.weixin.qq.com/api/doc#90000/90135/90254)
+`execMediaGet`|`reqMediaGet`|`io.ReadCloser`|+|`GET /cgi-bin/media/get`|[获取临时素材](https://work.weixin.qq.com/api/doc#90000/90135/90254)
 `execMediaGetJSSDK`|TODO|TODO|+|`GET /cgi-bin/media/get/jssdk`|[获取高清语音素材](https://work.weixin.qq.com/api/doc#90000/90135/90255)
 
 # OA 数据接口

--- a/media_api.go
+++ b/media_api.go
@@ -1,6 +1,7 @@
 package workwx
 
 import (
+	"io"
 	"strconv"
 	"time"
 )
@@ -71,6 +72,13 @@ func (c *WorkwxApp) mediaUploadImg(media *Media) (url string, err error) {
 	return resp.URL, nil
 }
 
+// mediaGet 获取临时素材
+func (c *WorkwxApp) mediaGet(mediaID string) (io.ReadCloser, error) {
+	return c.execMediaGet(reqMediaGet{
+		MediaID: mediaID,
+	})
+}
+
 //
 // convenient wrappers
 //
@@ -120,6 +128,11 @@ func (c *WorkwxApp) UploadTempFileMedia(media *Media) (*MediaUploadResult, error
 	}
 
 	return result, nil
+}
+
+// GetTempMedia 获取临时素材
+func (c *WorkwxApp) GetTempMedia(mediaID string) (io.ReadCloser, error) {
+	return c.mediaGet(mediaID)
 }
 
 // UploadPermanentImageMedia 上传永久图片素材

--- a/models.go
+++ b/models.go
@@ -516,6 +516,19 @@ type respMediaUploadImg struct {
 	URL string `json:"url"`
 }
 
+// reqMediaGet 获取临时素材请求
+type reqMediaGet struct {
+	MediaID string
+}
+
+var _ urlValuer = reqMediaGet{}
+
+func (x reqMediaGet) intoURLValues() url.Values {
+	return url.Values{
+		"media_id": {x.MediaID},
+	}
+}
+
 // reqExternalContactList 获取客户列表
 type reqExternalContactList struct {
 	UserID string `json:"userid"`


### PR DESCRIPTION
新增通过mediaid流式下载临时素材的API，已经在测试环境测试使用过

参考[官方文档-获取临时素材
](https://developer.work.weixin.qq.com/document/path/90254)
