### PR TITLE
Feat: 增加获取应用列表、获取应用信息的接口

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1,0 +1,63 @@
+package workwx
+
+// AgentInfo 应用信息
+type AgentInfo struct {
+	// AgentID 企业应用id
+	AgentID int64
+	// Name 企业应用名称
+	Name string
+	// SquareLogoURL 企业应用方形头像
+	SquareLogoURL string
+	// Description 企业应用详情
+	Description string
+	// AllowUserInfos 企业应用可见范围（人员）
+	AllowUserInfos AgentAllowUserInfos
+	// AllowPartys 企业应用可见范围（部门）
+	AllowPartys AgentAllowPartys
+	// AllowTags 企业应用可见范围（标签）
+	AllowTags AgentAllowTags
+	// Close 企业应用是否被停用。0：未被停用；1：被停用
+	Close int
+	// RedirectDomain 企业应用可信域名
+	RedirectDomain string
+	// ReportLocationFlag 企业应用是否打开地理位置上报 0：不上报；1：进入会话上报
+	ReportLocationFlag int
+	// IsReportEnter 是否上报用户进入应用事件。0：不接收；1：接收
+	IsReportEnter int
+	// HomeURL 应用主页url
+	HomeURL string
+	// CustomizedPublishStatus 代开发自建应用返回该字段，表示代开发发布状态。
+	// 0：待开发（企业已授权，服务商未创建应用）
+	// 1：开发中（服务商已创建应用，未上线）
+	// 2：已上线（服务商已上线应用且不存在未上线版本）
+	// 3：存在未上线版本（服务商已上线应用但存在未上线版本）
+	CustomizedPublishStatus int
+}
+
+// GetAgent 获取指定的应用详情
+func (c *WorkwxApp) GetAgent(agentID int64) (*AgentInfo, error) {
+	resp, err := c.execAgentGet(reqAgentGet{
+		AgentID: agentID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	agentInfo := &AgentInfo{
+		AgentID:                 resp.AgentID,
+		Name:                    resp.Name,
+		SquareLogoURL:           resp.SquareLogoURL,
+		Description:             resp.Description,
+		AllowUserInfos:          resp.AllowUserInfos,
+		AllowPartys:             resp.AllowPartys,
+		AllowTags:               resp.AllowTags,
+		Close:                   resp.Close,
+		RedirectDomain:          resp.RedirectDomain,
+		ReportLocationFlag:      resp.ReportLocationFlag,
+		IsReportEnter:           resp.IsReportEnter,
+		HomeURL:                 resp.HomeURL,
+		CustomizedPublishStatus: resp.CustomizedPublishStatus,
+	}
+
+	return agentInfo, nil
+}

--- a/agent.go
+++ b/agent.go
@@ -36,14 +36,13 @@ type AgentInfo struct {
 
 // GetCurrentAgentInfo 获取当前应用详情
 func (c *WorkwxApp) GetCurrentAgentInfo() (*AgentInfo, error) {
-	agentId := c.AgentID
-	return c.GetAgentInfo(agentId)
+	return c.GetAgentInfo(c.AgentID)
 }
 
 // GetAgentInfo 获取指定应用详情
-func (c *WorkwxApp) GetAgentInfo(agentId int64) (*AgentInfo, error) {
+func (c *WorkwxApp) GetAgentInfo(agentID int64) (*AgentInfo, error) {
 	resp, err := c.execAgentGetInfo(reqAgentGet{
-		AgentID: agentId,
+		AgentID: agentID,
 	})
 	if err != nil {
 		return nil, err

--- a/agent.go
+++ b/agent.go
@@ -34,10 +34,16 @@ type AgentInfo struct {
 	CustomizedPublishStatus int
 }
 
-// GetAgentInfo 获取应用详情
-func (c *WorkwxApp) GetAgentInfo() (*AgentInfo, error) {
+// GetCurrentAgentInfo 获取当前应用详情
+func (c *WorkwxApp) GetCurrentAgentInfo() (*AgentInfo, error) {
+	agentId := c.AgentID
+	return c.GetAgentInfo(agentId)
+}
+
+// GetAgentInfo 获取指定应用详情
+func (c *WorkwxApp) GetAgentInfo(agentId int64) (*AgentInfo, error) {
 	resp, err := c.execAgentGetInfo(reqAgentGet{
-		AgentID: c.AgentID,
+		AgentID: agentId,
 	})
 	if err != nil {
 		return nil, err

--- a/agent.go
+++ b/agent.go
@@ -34,9 +34,9 @@ type AgentInfo struct {
 	CustomizedPublishStatus int
 }
 
-// GetAgent 获取指定的应用详情
-func (c *WorkwxApp) GetAgent() (*AgentInfo, error) {
-	resp, err := c.execAgentGet(reqAgentGet{
+// GetAgentInfo 获取应用详情
+func (c *WorkwxApp) GetAgentInfo() (*AgentInfo, error) {
+	resp, err := c.execAgentGetInfo(reqAgentGet{
 		AgentID: c.AgentID,
 	})
 	if err != nil {

--- a/agent.go
+++ b/agent.go
@@ -61,3 +61,13 @@ func (c *WorkwxApp) GetAgentInfo() (*AgentInfo, error) {
 
 	return agentInfo, nil
 }
+
+// GetAgentList 获取应用列表
+func (c *WorkwxApp) GetAgentList() ([]AgentItem, error) {
+	resp, err := c.execAgentList(reqAgentList{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.AgentList, nil
+}

--- a/agent.go
+++ b/agent.go
@@ -35,9 +35,9 @@ type AgentInfo struct {
 }
 
 // GetAgent 获取指定的应用详情
-func (c *WorkwxApp) GetAgent(agentID int64) (*AgentInfo, error) {
+func (c *WorkwxApp) GetAgent() (*AgentInfo, error) {
 	resp, err := c.execAgentGet(reqAgentGet{
-		AgentID: agentID,
+		AgentID: c.AgentID,
 	})
 	if err != nil {
 		return nil, err

--- a/apis.md.go
+++ b/apis.md.go
@@ -965,3 +965,14 @@ func (c *WorkwxApp) execAgentGetInfo(req reqAgentGet) (respAgentGet, error) {
 
 	return resp, nil
 }
+
+// execAgentList 获取应用列表
+func (c *WorkwxApp) execAgentList(req reqAgentList) (respAgentList, error) {
+	var resp respAgentList
+	err := executeQyapiGet(c, "/cgi-bin/agent/list", req, &resp, true)
+	if err != nil {
+		return respAgentList{}, err
+	}
+
+	return resp, nil
+}

--- a/apis.md.go
+++ b/apis.md.go
@@ -955,8 +955,8 @@ func (c *WorkwxApp) execKfCustomerBatchGet(req reqKfCustomerBatchGet) (respKfCus
 	return resp, nil
 }
 
-// execAgentGet 获取指定的应用详情
-func (c *WorkwxApp) execAgentGet(req reqAgentGet) (respAgentGet, error) {
+// execAgentGetInfo 获取指定的应用详情
+func (c *WorkwxApp) execAgentGetInfo(req reqAgentGet) (respAgentGet, error) {
 	var resp respAgentGet
 	err := executeQyapiGet(c, "/cgi-bin/agent/get", req, &resp, true)
 	if err != nil {

--- a/apis.md.go
+++ b/apis.md.go
@@ -954,3 +954,14 @@ func (c *WorkwxApp) execKfCustomerBatchGet(req reqKfCustomerBatchGet) (respKfCus
 
 	return resp, nil
 }
+
+// execAgentGet 获取指定的应用详情
+func (c *WorkwxApp) execAgentGet(req reqAgentGet) (respAgentGet, error) {
+	var resp respAgentGet
+	err := executeQyapiGet(c, "/cgi-bin/agent/get", req, &resp, true)
+	if err != nil {
+		return respAgentGet{}, err
+	}
+
+	return resp, nil
+}

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -125,7 +125,7 @@ Name|Request Type|Response Type|Access Token|URL|Doc
 Name|Request Type|Response Type|Access Token|URL|Doc
 :---|------------|-------------|------------|:--|:--
 `execAgentGet`|`reqAgentGet`|`respAgentGet`|+|`GET /cgi-bin/agent/get`|[获取指定的应用详情](https://work.weixin.qq.com/api/doc#90000/90135/90227)
-`execAgentList`|TODO|TODO|+|`GET /cgi-bin/agent/list`|[获取access_token对应的应用列表](https://work.weixin.qq.com/api/doc#90000/90135/90227)
+`execAgentList`|`reqAgentList`|`respAgentList`|+|`GET /cgi-bin/agent/list`|[获取access_token对应的应用列表](https://work.weixin.qq.com/api/doc#90000/90135/90227)
 `execAgentSet`|TODO|TODO|+|`POST /cgi-bin/agent/set`|[设置应用](https://work.weixin.qq.com/api/doc#90000/90135/90228)
 
 # 应用管理 - 自定义菜单

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -124,7 +124,7 @@ Name|Request Type|Response Type|Access Token|URL|Doc
 
 Name|Request Type|Response Type|Access Token|URL|Doc
 :---|------------|-------------|------------|:--|:--
-`execAgentGet`|TODO|TODO|+|`GET /cgi-bin/agent/get`|[获取指定的应用详情](https://work.weixin.qq.com/api/doc#90000/90135/90227)
+`execAgentGet`|`reqAgentGet`|`respAgentGet`|+|`GET /cgi-bin/agent/get`|[获取指定的应用详情](https://work.weixin.qq.com/api/doc#90000/90135/90227)
 `execAgentList`|TODO|TODO|+|`GET /cgi-bin/agent/list`|[获取access_token对应的应用列表](https://work.weixin.qq.com/api/doc#90000/90135/90227)
 `execAgentSet`|TODO|TODO|+|`POST /cgi-bin/agent/set`|[设置应用](https://work.weixin.qq.com/api/doc#90000/90135/90228)
 

--- a/example_test.go
+++ b/example_test.go
@@ -305,7 +305,7 @@ func ExampleWorkwxApp_GetAgentInfo() {
 	app.SpawnAccessTokenRefresher()
 
 	// 获取应用详情
-	agentInfo, err := app.GetAgentInfo()
+	agentInfo, err := app.GetCurrentAgentInfo()
 	if err != nil {
 		// 处理错误
 		return

--- a/example_test.go
+++ b/example_test.go
@@ -296,7 +296,7 @@ func ExampleWorkwxApp_ApplyOAEvent() {
 	_, _ = app.ApplyOAEvent(appInfo)
 }
 
-func ExampleWorkwxApp_GetAgent() {
+func ExampleWorkwxApp_GetAgentInfo() {
 	agentID := int64(1234567)
 
 	client := workwx.New(corpID)

--- a/example_test.go
+++ b/example_test.go
@@ -305,7 +305,7 @@ func ExampleWorkwxApp_GetAgent() {
 	app.SpawnAccessTokenRefresher()
 
 	// 获取应用详情
-	agentInfo, err := app.GetAgent(agentID)
+	agentInfo, err := app.GetAgentInfo()
 	if err != nil {
 		// 处理错误
 		return

--- a/example_test.go
+++ b/example_test.go
@@ -295,3 +295,25 @@ func ExampleWorkwxApp_ApplyOAEvent() {
 	}
 	_, _ = app.ApplyOAEvent(appInfo)
 }
+
+func ExampleWorkwxApp_GetAgent() {
+	agentID := int64(1234567)
+
+	client := workwx.New(corpID)
+
+	app := client.WithApp(corpSecret, agentID)
+	app.SpawnAccessTokenRefresher()
+
+	// 获取应用详情
+	agentInfo, err := app.GetAgent(agentID)
+	if err != nil {
+		// 处理错误
+		return
+	}
+
+	// 使用应用信息
+	_ = agentInfo.Name
+	_ = agentInfo.Description
+	_ = agentInfo.SquareLogoURL
+	// ... 其他字段
+}

--- a/models.go
+++ b/models.go
@@ -2255,3 +2255,29 @@ type AgentAllowPartys struct {
 type AgentAllowTags struct {
 	TagID []int64 `json:"tagid"`
 }
+
+// reqAgentList 获取应用列表请求
+type reqAgentList struct{}
+
+var _ urlValuer = reqAgentList{}
+
+func (x reqAgentList) intoURLValues() url.Values {
+	return url.Values{}
+}
+
+// AgentItem 应用列表项
+type AgentItem struct {
+	// AgentID 企业应用id
+	AgentID int64 `json:"agentid"`
+	// Name 企业应用名称
+	Name string `json:"name"`
+	// SquareLogoURL 企业应用方形头像url
+	SquareLogoURL string `json:"square_logo_url"`
+}
+
+// respAgentList 获取应用列表响应
+type respAgentList struct {
+	respCommon
+
+	AgentList []AgentItem `json:"agentlist"`
+}

--- a/models.go
+++ b/models.go
@@ -2202,3 +2202,55 @@ func (x reqOASetOneUserVacationQuota) intoBody() ([]byte, error) {
 type respOASetOneUserVacationQuota struct {
 	respCommon
 }
+
+// reqAgentGet 获取应用详情请求
+type reqAgentGet struct {
+	AgentID int64
+}
+
+var _ urlValuer = reqAgentGet{}
+
+func (x reqAgentGet) intoURLValues() url.Values {
+	return url.Values{
+		"agentid": {strconv.FormatInt(x.AgentID, 10)},
+	}
+}
+
+// respAgentGet 获取应用详情响应
+type respAgentGet struct {
+	respCommon
+
+	AgentID                 int64               `json:"agentid"`
+	Name                    string              `json:"name"`
+	SquareLogoURL           string              `json:"square_logo_url"`
+	Description             string              `json:"description"`
+	AllowUserInfos          AgentAllowUserInfos `json:"allow_userinfos"`
+	AllowPartys             AgentAllowPartys    `json:"allow_partys"`
+	AllowTags               AgentAllowTags      `json:"allow_tags"`
+	Close                   int                 `json:"close"`
+	RedirectDomain          string              `json:"redirect_domain"`
+	ReportLocationFlag      int                 `json:"report_location_flag"`
+	IsReportEnter           int                 `json:"isreportenter"`
+	HomeURL                 string              `json:"home_url"`
+	CustomizedPublishStatus int                 `json:"customized_publish_status"`
+}
+
+// AgentAllowUserInfos 应用可见范围（人员）
+type AgentAllowUserInfos struct {
+	User []AgentAllowUser `json:"user"`
+}
+
+// AgentAllowUser 应用可见用户
+type AgentAllowUser struct {
+	UserID string `json:"userid"`
+}
+
+// AgentAllowPartys 应用可见范围（部门）
+type AgentAllowPartys struct {
+	PartyID []int64 `json:"partyid"`
+}
+
+// AgentAllowTags 应用可见范围（标签）
+type AgentAllowTags struct {
+	TagID []int64 `json:"tagid"`
+}


### PR DESCRIPTION
新增了两个 获取 Agent 信息的接口，对应企业微信官方文档：

- 获取指定的应用详情: GET /cgi-bin/agent/get [获取指定的应用详情](https://work.weixin.qq.com/api/doc#90000/90135/90227)

- 获取 access_token 对应的应用列表: GET /cgi-bin/agent/list [获取access_token对应的应用列表](https://work.weixin.qq.com/api/doc#90000/90135/90227)
